### PR TITLE
Fix compile issue where int10 would cause a compile error

### DIFF
--- a/cflexparser/Makefile
+++ b/cflexparser/Makefile
@@ -9,7 +9,8 @@ $(PARSER_C):
 	@rm clangparser.cxx
 
 clangparser.so: $(PARSER_C)
-	$(CC) -o clangparser.so -shared $(PARSER_C) -fPIC $(shell python3-config --cflags --ldflags)
+	$(CC) -o clangparser.so -shared $(PARSER_C) -fPIC $(shell python3-config --embed --cflags --ldflags)
+
 
 clean:
 	rm -Rf clangparser.so $(PARSER_C) clangparser.cxx __pycache__ private/__pycache__

--- a/include/silice_compat.h
+++ b/include/silice_compat.h
@@ -8,7 +8,7 @@ typedef unsigned long long uint33;
 typedef unsigned uint17, uint20, uint21, uint22, uint23, uint24, uint25, uint26, uint28, uint31, uint32;
 typedef unsigned short uint9, uint10, uint11, uint12, uint15, uint16;
 typedef unsigned char uint3, uint4, uint6, uint8, uint7, uint1;
-typedef signed short int16;
+typedef signed short int16, int10;
 typedef int int21, int27, int31, int32;
 
 struct silice_module {};

--- a/src/sim_fb.c
+++ b/src/sim_fb.c
@@ -1,7 +1,11 @@
 // Simple framebuffer windows for visualizations
 // Copyright (C) 2022 Victor Suarez Rovere <suarezvictor@gmail.com>
 
-#include <SDL2/SDL.h>
+#ifdef __APPLE__
+    #include <SDL.h>
+#else
+    #include <SDL2/SDL.h>
+#endif 
 #include "sim_fb.h"
 
 bool fb_init(unsigned width, unsigned height, bool vsync, fb_handle_t *handle)


### PR DESCRIPTION
Hello.  Thanks for this project.  Haven't had much time to do anything with it, but I intend to, and hope it can stick around and grow.

I had some minor issues getting the latest to compile on my MacOS (M1).
The first issue was the clangparser itself ... I could never get it to work in any version, unless I added --embed to the clang parser.so target.


Second was I had to add  a typedef for int10 in silice_compat.h


Third was sdl_config on Mac points into sdl2 include directory, so I had to remove that from the include in sim_fb.c in order to get it to compile.